### PR TITLE
fix: make checkstyle occur build failure when lint failed

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -19,7 +19,6 @@ configurations.all {
 
 checkstyle {
 	maxWarnings = 0
-	ignoreFailures = true
 	configFile = file("${rootDir}/config/gpu-im-checkstyle.xml")
 }
 


### PR DESCRIPTION
## 변경하고자 하는 프로그램
Backend(spring)

## 변경 부분
checkstyle configuration

## 변경 내용
Checkstyle 플러그인이 lint 오류를 Warn 레벨로 무시하지 않고 Build Failure를 발생시키게 설정했습니다.

close #19 