### PR TITLE
feat: integrate flyway with spring boot/gradle and make migration script/environment

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -39,3 +39,6 @@ out/
 application.properties
 
 **/*.log
+
+## For Flyway Integration with Spring Boot
+generated_scheme.sql

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'checkstyle'
+	id 'org.flywaydb.flyway' version '9.4.0'
 }
 
 group = 'deu.ac.kr'
@@ -38,11 +39,13 @@ configurations {
 }
 
 dependencies {
+	// SpringBoot
+	implementation 'org.springframework.boot:spring-boot:2.7.4'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-devtools:2.7.1'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.0'
-	implementation 'org.springframework.boot:spring-boot-starter-aop:2.7.0'
+	implementation 'org.springframework.boot:spring-boot-devtools:2.7.4'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.4'
+	implementation 'org.springframework.boot:spring-boot-starter-aop:2.7.4'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
@@ -76,6 +79,10 @@ dependencies {
 	// Sentry
 	implementation 'io.sentry:sentry-log4j2:6.3.0'
 	implementation 'io.sentry:sentry-spring-boot-starter:6.3.0'
+
+	// Flyway DB
+	implementation 'org.flywaydb:flyway-core' // Downgraded to 8 because spring still not support 9
+	implementation 'org.flywaydb:flyway-mysql'
 
 	// Junit4
 	testImplementation(platform('org.junit:junit-bom:5.8.2'))

--- a/backend/src/main/resources/migration/rdb/V1__BASE_SRC.sql
+++ b/backend/src/main/resources/migration/rdb/V1__BASE_SRC.sql
@@ -1,0 +1,12 @@
+create table user (
+    id bigint not null auto_increment,
+    created_at datetime(6) not null,
+    email varchar(255) not null,
+    gender integer not null,
+    job varchar(255),
+    last_login datetime(6),
+    password varchar(255) not null,
+    role integer not null,
+    username varchar(255) not null,
+    primary key (id)
+) engine=InnoDB;


### PR DESCRIPTION


## 변경하고자 하는 프로그램
Backend(Spring Boot)

## 변경 부분
Spring Boot DevOps - DB Migration

## 변경 내용
- Flyway와 Spring Boot/Gradle 환경을 통합했습니다.
- Flyway Migration을 위한 V1 스크립트를 추가했습니다.
- Hibernate에서 데이터 추가가 있을 경우 Project Root에 generated_scheme.sql 파일을 생성하여 이를 Migrate 하는 데 사용할 수 있도록 했습니다.

TODO: DB Migration에 대한 설명이 README.md에 필요합니다.

## 마이그레이션 방법
앞으로 Database Entity를 추가할 때는 해당 Entity를 생성하는 Migration Script를 작성/생성된 스크립트를 복사하시기 바랍니다.
또한, 만약 DB Schema에 수정이 일어날 때는, 수정 관련 데이터를 반드시 **새 버전으로** Scheme 버전에 추가하셔야 합니다.